### PR TITLE
Add remaining doctests

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,10 +285,15 @@ API breaking changes:
   This function returns now `Result<(), QuestError>`.
 
 - Change signature of the following functions:
+
   - `apply_pauli_sum()`
-  - `applu_pauli_hamil()`
-  These function take argument `in_qureg` as `&mut` now (instead of a shared
+  - `apply_pauli_hamil()`
+
+  These functions take argument `in_qureg` as `&mut` now (instead of a shared
   reference).
+
+- Fix typo in the function name: `apply_trotter_circuit()` (was:
+  `apply_trotter_circuitit()`).
 
 ### v0.2.0 (24/06/2023)
 

--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ API breaking changes:
 
 - Fix typo in the function name: `apply_trotter_circuit()` (was:
   `apply_trotter_circuitit()`).
+- Function: `multi_controlled_multi_rotate_pauli()` changes signature.
 
 ### v0.2.1 (01/07/2023)
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,12 @@ API breaking changes:
 
   This function returns now `Result<(), QuestError>`.
 
+- Change signature of the following functions:
+  - `apply_pauli_sum()`
+  - `applu_pauli_hamil()`
+  These function take argument `in_qureg` as `&mut` now (instead of a shared
+  reference).
+
 ### v0.2.0 (24/06/2023)
 
 New features/improvements:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4562,7 +4562,7 @@ pub fn apply_pauli_hamil(
 /// See [QuEST API][1] for more information.
 ///
 /// [1]: https://quest-kit.github.io/QuEST/modules.html
-pub fn apply_trotter_circuitit(
+pub fn apply_trotter_circuit(
     qureg: &mut Qureg,
     hamil: &PauliHamil,
     time: Qreal,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4513,7 +4513,7 @@ pub fn set_weighted_qureg(
 ///
 /// [1]: https://quest-kit.github.io/QuEST/modules.html
 pub fn apply_pauli_sum(
-    in_qureg: &Qureg,
+    in_qureg: &mut Qureg,
     all_pauli_codes: &[PauliOpType],
     term_coeffs: &[Qreal],
     out_qureg: &mut Qureg,
@@ -4542,7 +4542,7 @@ pub fn apply_pauli_sum(
 ///
 /// [1]: https://quest-kit.github.io/QuEST/modules.html
 pub fn apply_pauli_hamil(
-    in_qureg: &Qureg,
+    in_qureg: &mut Qureg,
     hamil: &PauliHamil,
     out_qureg: &mut Qureg,
 ) -> Result<(), QuestError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4501,12 +4501,34 @@ pub fn set_weighted_qureg(
     })
 }
 
-/// Desc.
+/// Modifies `out_qureg` to be the result of applying the weighted sum of Pauli
+/// products.
+///
+/// In theory, `in_qureg` is unchanged though its state is temporarily modified
+/// and is reverted by re-applying Paulis (XX=YY=ZZ=I), so may see a change by
+/// small numerical errors. The initial state in `out_qureg` is not used.
 ///
 /// # Examples
 ///
 /// ```rust
 /// # use quest_bind::*;
+/// use PauliOpType::{
+///     PAULI_I,
+///     PAULI_X,
+/// };
+/// let env = &QuestEnv::new();
+/// let in_qureg = &mut Qureg::try_new(2, env).unwrap();
+/// init_zero_state(in_qureg);
+/// let out_qureg = &mut Qureg::try_new(2, env).unwrap();
+/// let all_pauli_codes = &[PAULI_I, PAULI_X, PAULI_X, PAULI_I];
+/// let term_coeffs = &[SQRT_2.recip(), SQRT_2.recip()];
+///
+/// apply_pauli_sum(in_qureg, all_pauli_codes, term_coeffs, out_qureg).unwrap();
+///
+/// // out_qureg is now in `|01> + |10>` state:
+/// let qb1 = measure(out_qureg, 0).unwrap();
+/// let qb2 = measure(out_qureg, 1).unwrap();
+/// assert!(qb1 != qb2);
 /// ```
 ///
 /// See [QuEST API][1] for more information.
@@ -4528,6 +4550,27 @@ pub fn apply_pauli_sum(
             out_qureg.reg,
         );
     })
+}
+
+#[test]
+fn apply_pauli_hamil_01() {
+    use PauliOpType::{
+        PAULI_I,
+        PAULI_X,
+    };
+    let env = &QuestEnv::new();
+    let in_qureg = &mut Qureg::try_new(2, env).unwrap();
+    init_zero_state(in_qureg);
+    let out_qureg = &mut Qureg::try_new(2, env).unwrap();
+    let all_pauli_codes = &[PAULI_I, PAULI_X, PAULI_X, PAULI_I];
+    let term_coeffs = &[SQRT_2.recip(), SQRT_2.recip()];
+
+    apply_pauli_sum(in_qureg, all_pauli_codes, term_coeffs, out_qureg).unwrap();
+
+    // out_qureg is now in `|01> + |10>` state:
+    let qb1 = measure(out_qureg, 0).unwrap();
+    let qb2 = measure(out_qureg, 1).unwrap();
+    assert!(qb1 != qb2);
 }
 
 /// Desc.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4516,6 +4516,7 @@ pub fn set_weighted_qureg(
 ///     PAULI_I,
 ///     PAULI_X,
 /// };
+///
 /// let env = &QuestEnv::new();
 /// let in_qureg = &mut Qureg::try_new(2, env).unwrap();
 /// init_zero_state(in_qureg);
@@ -4552,33 +4553,33 @@ pub fn apply_pauli_sum(
     })
 }
 
-#[test]
-fn apply_pauli_hamil_01() {
-    use PauliOpType::{
-        PAULI_I,
-        PAULI_X,
-    };
-    let env = &QuestEnv::new();
-    let in_qureg = &mut Qureg::try_new(2, env).unwrap();
-    init_zero_state(in_qureg);
-    let out_qureg = &mut Qureg::try_new(2, env).unwrap();
-    let all_pauli_codes = &[PAULI_I, PAULI_X, PAULI_X, PAULI_I];
-    let term_coeffs = &[SQRT_2.recip(), SQRT_2.recip()];
-
-    apply_pauli_sum(in_qureg, all_pauli_codes, term_coeffs, out_qureg).unwrap();
-
-    // out_qureg is now in `|01> + |10>` state:
-    let qb1 = measure(out_qureg, 0).unwrap();
-    let qb2 = measure(out_qureg, 1).unwrap();
-    assert!(qb1 != qb2);
-}
-
 /// Desc.
 ///
 /// # Examples
 ///
 /// ```rust
 /// # use quest_bind::*;
+/// use PauliOpType::{
+///     PAULI_I,
+///     PAULI_X,
+/// };
+///
+/// let env = &QuestEnv::new();
+/// let in_qureg = &mut Qureg::try_new(2, env).unwrap();
+/// init_zero_state(in_qureg);
+/// let out_qureg = &mut Qureg::try_new(2, env).unwrap();
+///
+/// let hamil = &mut PauliHamil::try_new(2, 2).unwrap();
+/// let coeffs = &[SQRT_2.recip(), SQRT_2.recip()];
+/// let codes = &[PAULI_I, PAULI_X, PAULI_X, PAULI_I];
+/// init_pauli_hamil(hamil, coeffs, codes).unwrap();
+///
+/// apply_pauli_hamil(in_qureg, hamil, out_qureg).unwrap();
+///
+/// // out_qureg is now in `|01> + |10>` state:
+/// let qb1 = measure(out_qureg, 0).unwrap();
+/// let qb2 = measure(out_qureg, 1).unwrap();
+/// assert!(qb1 != qb2);
 /// ```
 ///
 /// See [QuEST API][1] for more information.
@@ -4592,6 +4593,30 @@ pub fn apply_pauli_hamil(
     catch_quest_exception(|| unsafe {
         ffi::applyPauliHamil(in_qureg.reg, hamil.0, out_qureg.reg);
     })
+}
+
+#[test]
+fn apply_trotter_circuit_01() {
+    use PauliOpType::{
+        PAULI_I,
+        PAULI_X,
+    };
+    let env = &QuestEnv::new();
+    let in_qureg = &mut Qureg::try_new(2, env).unwrap();
+    init_zero_state(in_qureg);
+    let out_qureg = &mut Qureg::try_new(2, env).unwrap();
+
+    let hamil = &mut PauliHamil::try_new(2, 2).unwrap();
+    let coeffs = &[SQRT_2.recip(), SQRT_2.recip()];
+    let codes = &[PAULI_I, PAULI_X, PAULI_X, PAULI_I];
+    init_pauli_hamil(hamil, coeffs, codes).unwrap();
+
+    apply_pauli_hamil(in_qureg, hamil, out_qureg).unwrap();
+
+    // out_qureg is now in `|01> + |10>` state:
+    let qb1 = measure(out_qureg, 0).unwrap();
+    let qb2 = measure(out_qureg, 1).unwrap();
+    assert!(qb1 != qb2);
 }
 
 /// Desc.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4470,12 +4470,38 @@ pub fn calc_hilbert_schmidt_distance(
     })
 }
 
-/// Desc.
+/// Modifies qureg \p out to the result of `$(\p facOut \p out + \p fac1 \p
+/// qureg1 + \p fac2 \p qureg2)$`, imposing no constraints on normalisation.
+///
+/// Works for both state-vectors and density matrices. Note that afterward, \p
+/// out may not longer be normalised and ergo no longer a valid  state-vector or
+/// density matrix. Users must therefore be careful passing \p out to other
+/// QuEST functions which assume normalisation in order to function correctly.
 ///
 /// # Examples
 ///
 /// ```rust
 /// # use quest_bind::*;
+/// # use num::Zero;
+/// let env = &QuestEnv::new();
+/// let qureg1 = &mut Qureg::try_new(1, env).unwrap();
+/// init_zero_state(qureg1);
+/// let qureg2 = &mut Qureg::try_new(1, env).unwrap();
+/// init_zero_state(qureg2);
+/// pauli_x(qureg2, 0).unwrap();
+///
+/// let out = &mut Qureg::try_new(1, env).unwrap();
+/// init_zero_state(out);
+///
+/// let fac1 = Qcomplex::new(SQRT_2.recip(), 0.);
+/// let fac2 = Qcomplex::new(SQRT_2.recip(), 0.);
+/// let fac_out = Qcomplex::zero();
+///
+/// set_weighted_qureg(fac1, qureg1, fac2, qureg2, fac_out, out).unwrap();
+///
+/// hadamard(out, 0).unwrap();
+/// let amp = get_real_amp(out, 0).unwrap();
+/// assert!((amp - 1.).abs() < 10. * EPSILON);
 /// ```
 ///
 /// See [QuEST API][1] for more information.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3504,12 +3504,33 @@ pub fn multi_rotate_pauli(
     })
 }
 
-/// Desc.
+/// Apply a multi-controlled multi-target Z rotation.
 ///
 /// # Examples
 ///
 /// ```rust
 /// # use quest_bind::*;
+/// let env = &QuestEnv::new();
+/// let qureg = &mut Qureg::try_new(4, env).unwrap();
+///
+/// // Initialize `|1111>`
+/// init_zero_state(qureg);
+/// (0..4).try_for_each(|i| pauli_x(qureg, i)).unwrap();
+///
+/// let control_qubits = &[0, 1];
+/// let target_qubits = &[2, 3];
+/// let angle = 2. * PI;
+/// multi_controlled_multi_rotate_z(
+///     qureg,
+///     control_qubits,
+///     target_qubits,
+///     angle,
+/// )
+/// .unwrap();
+///
+/// // the state is now `-1. * |1111>`
+/// let amp = get_real_amp(qureg, 15).unwrap();
+/// assert!((amp + 1.).abs() < EPSILON);
 /// ```
 ///
 /// See [QuEST API][1] for more information.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1494,12 +1494,16 @@ pub fn get_environment_string(env: &QuestEnv) -> Result<String, QuestError> {
     .expect("get_environment_string should always succeed")
 }
 
-/// Desc.
+/// Copy the state-vector (or density matrix) from RAM to VRAM / GPU-memory.
 ///
 /// # Examples
 ///
 /// ```rust
 /// # use quest_bind::*;
+/// let env = &QuestEnv::new();
+/// let qureg = &mut Qureg::try_new(2, env).unwrap();
+///
+/// copy_state_to_gpu(qureg);
 /// ```
 ///
 /// See [QuEST API][1] for more information.
@@ -1513,6 +1517,16 @@ pub fn copy_state_to_gpu(qureg: &mut Qureg) {
 }
 
 /// In GPU mode, this copies the state-vector (or density matrix) from RAM.
+///
+/// # Examples
+///
+/// ```rust
+/// # use quest_bind::*;
+/// let env = &QuestEnv::new();
+/// let qureg = &mut Qureg::try_new(2, env).unwrap();
+///
+/// copy_state_from_gpu(qureg);
+/// ```
 ///
 /// See [QuEST API][1] for more information.
 ///

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3283,3 +3283,42 @@ fn apply_pauli_sum_03() {
 
     apply_pauli_sum(in_qureg, all_pauli_codes, term_coeffs, out_qureg).unwrap();
 }
+
+#[test]
+fn apply_pauli_hamil_01() {
+    use PauliOpType::{
+        PAULI_I,
+        PAULI_X,
+    };
+    let env = &QuestEnv::new();
+    let in_qureg = &mut Qureg::try_new(2, env).unwrap();
+    init_zero_state(in_qureg);
+    let out_qureg = &mut Qureg::try_new(2, env).unwrap();
+
+    let hamil = &mut PauliHamil::try_new(2, 2).unwrap();
+    let coeffs = &[SQRT_2.recip(), SQRT_2.recip()];
+    let codes = &[PAULI_I, PAULI_X, PAULI_X, PAULI_I];
+    init_pauli_hamil(hamil, coeffs, codes).unwrap();
+
+    apply_pauli_hamil(in_qureg, hamil, out_qureg).unwrap();
+}
+
+#[test]
+fn apply_pauli_hamil_02() {
+    use PauliOpType::{
+        PAULI_I,
+        PAULI_X,
+    };
+    let env = &QuestEnv::new();
+    let in_qureg = &mut Qureg::try_new(2, env).unwrap();
+    init_zero_state(in_qureg);
+    // out_qureg is of different dimension
+    let out_qureg = &mut Qureg::try_new(3, env).unwrap();
+
+    let hamil = &mut PauliHamil::try_new(2, 2).unwrap();
+    let coeffs = &[SQRT_2.recip(), SQRT_2.recip()];
+    let codes = &[PAULI_I, PAULI_X, PAULI_X, PAULI_I];
+    init_pauli_hamil(hamil, coeffs, codes).unwrap();
+
+    apply_pauli_hamil(in_qureg, hamil, out_qureg).unwrap_err();
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3322,3 +3322,25 @@ fn apply_pauli_hamil_02() {
 
     apply_pauli_hamil(in_qureg, hamil, out_qureg).unwrap_err();
 }
+
+#[test]
+fn apply_trotter_circuit_01() {
+    use PauliOpType::PAULI_X;
+
+    let env = &QuestEnv::new();
+    let qureg = &mut Qureg::try_new(1, env).unwrap();
+    init_zero_state(qureg);
+
+    let hamil = &mut PauliHamil::try_new(1, 1).unwrap();
+    let coeffs = &[1.];
+    let codes = &[PAULI_X];
+    init_pauli_hamil(hamil, coeffs, codes).unwrap();
+
+    apply_trotter_circuit(qureg, hamil, 0., 1, 1).unwrap();
+    apply_trotter_circuit(qureg, hamil, 0., 2, 1).unwrap();
+    apply_trotter_circuit(qureg, hamil, 0., 1, 2).unwrap();
+
+    apply_trotter_circuit(qureg, hamil, 0., -1, 1).unwrap_err();
+    apply_trotter_circuit(qureg, hamil, 0., 1, 0).unwrap_err();
+    apply_trotter_circuit(qureg, hamil, 0., 1, -1).unwrap_err();
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3425,3 +3425,28 @@ fn set_weighted_qureg_04() {
 
     set_weighted_qureg(fac1, qureg1, fac2, qureg2, fac_out, out).unwrap_err();
 }
+
+#[test]
+fn multi_controlled_multi_rotate_z_01() {
+    let env = &QuestEnv::new();
+    let qureg = &mut Qureg::try_new(4, env).unwrap();
+
+    // Initialize `|1111>`
+    init_zero_state(qureg);
+    (0..4).try_for_each(|i| pauli_x(qureg, i)).unwrap();
+
+    multi_controlled_multi_rotate_z(qureg, &[0, 1], &[2, 3], 0.).unwrap();
+    multi_controlled_multi_rotate_z(qureg, &[0, 2], &[1, 3], 0.).unwrap();
+    multi_controlled_multi_rotate_z(qureg, &[2, 1], &[3, 0], 0.).unwrap();
+
+    multi_controlled_multi_rotate_z(qureg, &[0, 0], &[2, 3], 0.).unwrap_err();
+    multi_controlled_multi_rotate_z(qureg, &[0, 1], &[2, 2], 0.).unwrap_err();
+
+    multi_controlled_multi_rotate_z(qureg, &[-1, 1], &[2, 3], 0.).unwrap_err();
+    multi_controlled_multi_rotate_z(qureg, &[0, 4], &[2, 3], 0.).unwrap_err();
+    multi_controlled_multi_rotate_z(qureg, &[0, 1], &[-1, 3], 0.).unwrap_err();
+    multi_controlled_multi_rotate_z(qureg, &[0, 1], &[2, 4], 0.).unwrap_err();
+
+    multi_controlled_multi_rotate_z(qureg, &[0, 1], &[0, 3], 0.).unwrap_err();
+    multi_controlled_multi_rotate_z(qureg, &[0, 3], &[2, 3], 0.).unwrap_err();
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3231,3 +3231,55 @@ fn multi_controlled_multi_qubit_unitary_01() {
     let amp = get_real_amp(qureg, 15).unwrap();
     assert!((amp - 1.).abs() < EPSILON);
 }
+
+#[test]
+fn apply_pauli_sum_01() {
+    use PauliOpType::{
+        PAULI_I,
+        PAULI_X,
+    };
+    let env = &QuestEnv::new();
+    let in_qureg = &mut Qureg::try_new(2, env).unwrap();
+    init_zero_state(in_qureg);
+    let out_qureg = &mut Qureg::try_new(2, env).unwrap();
+    let all_pauli_codes = &[PAULI_I, PAULI_X, PAULI_X, PAULI_I];
+    let term_coeffs = &[SQRT_2.recip(), SQRT_2.recip()];
+
+    apply_pauli_sum(in_qureg, all_pauli_codes, term_coeffs, out_qureg).unwrap();
+}
+
+#[test]
+fn apply_pauli_sum_02() {
+    use PauliOpType::{
+        PAULI_I,
+        PAULI_X,
+    };
+    let env = &QuestEnv::new();
+    let in_qureg = &mut Qureg::try_new(2, env).unwrap();
+    init_zero_state(in_qureg);
+    let out_qureg = &mut Qureg::try_new(3, env).unwrap();
+    let all_pauli_codes = &[PAULI_I, PAULI_X, PAULI_X, PAULI_I];
+    let term_coeffs = &[SQRT_2.recip(), SQRT_2.recip()];
+
+    // in_ and out_qureg' dimensions are different
+    apply_pauli_sum(in_qureg, all_pauli_codes, term_coeffs, out_qureg)
+        .unwrap_err();
+}
+
+#[test]
+fn apply_pauli_sum_03() {
+    use PauliOpType::{
+        PAULI_I,
+        PAULI_X,
+    };
+    let env = &QuestEnv::new();
+    let in_qureg = &mut Qureg::try_new(2, env).unwrap();
+    init_zero_state(in_qureg);
+    let out_qureg = &mut Qureg::try_new(2, env).unwrap();
+
+    // wrong number of codes
+    let all_pauli_codes = &[PAULI_I, PAULI_X, PAULI_X];
+    let term_coeffs = &[SQRT_2.recip(), SQRT_2.recip()];
+
+    apply_pauli_sum(in_qureg, all_pauli_codes, term_coeffs, out_qureg).unwrap();
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3450,3 +3450,43 @@ fn multi_controlled_multi_rotate_z_01() {
     multi_controlled_multi_rotate_z(qureg, &[0, 1], &[0, 3], 0.).unwrap_err();
     multi_controlled_multi_rotate_z(qureg, &[0, 3], &[2, 3], 0.).unwrap_err();
 }
+
+#[test]
+fn multi_controlled_multi_rotate_pauli_01() {
+    use PauliOpType::PAULI_Z;
+
+    let env = &QuestEnv::new();
+    let qureg = &mut Qureg::try_new(4, env).unwrap();
+
+    // Initialize `|1111>`
+    init_zero_state(qureg);
+    (0..4).try_for_each(|i| pauli_x(qureg, i)).unwrap();
+
+    let tar_paul = &[PAULI_Z, PAULI_Z];
+
+    multi_controlled_multi_rotate_pauli(qureg, &[0, 1], &[2, 3], tar_paul, 0.)
+        .unwrap();
+    multi_controlled_multi_rotate_pauli(qureg, &[0, 2], &[1, 3], tar_paul, 0.)
+        .unwrap();
+    multi_controlled_multi_rotate_pauli(qureg, &[2, 1], &[3, 0], tar_paul, 0.)
+        .unwrap();
+
+    multi_controlled_multi_rotate_pauli(qureg, &[0, 0], &[2, 3], tar_paul, 0.)
+        .unwrap_err();
+    multi_controlled_multi_rotate_pauli(qureg, &[0, 1], &[2, 2], tar_paul, 0.)
+        .unwrap_err();
+
+    multi_controlled_multi_rotate_pauli(qureg, &[-1, 1], &[2, 3], tar_paul, 0.)
+        .unwrap_err();
+    multi_controlled_multi_rotate_pauli(qureg, &[0, 4], &[2, 3], tar_paul, 0.)
+        .unwrap_err();
+    multi_controlled_multi_rotate_pauli(qureg, &[0, 1], &[-1, 3], tar_paul, 0.)
+        .unwrap_err();
+    multi_controlled_multi_rotate_pauli(qureg, &[0, 1], &[2, 4], tar_paul, 0.)
+        .unwrap_err();
+
+    multi_controlled_multi_rotate_pauli(qureg, &[0, 1], &[0, 3], tar_paul, 0.)
+        .unwrap_err();
+    multi_controlled_multi_rotate_pauli(qureg, &[0, 3], &[2, 3], tar_paul, 0.)
+        .unwrap_err();
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::cast_sign_loss)]
 
+use num::Zero;
+
 use super::*;
 
 #[test]
@@ -3343,4 +3345,83 @@ fn apply_trotter_circuit_01() {
     apply_trotter_circuit(qureg, hamil, 0., -1, 1).unwrap_err();
     apply_trotter_circuit(qureg, hamil, 0., 1, 0).unwrap_err();
     apply_trotter_circuit(qureg, hamil, 0., 1, -1).unwrap_err();
+}
+
+#[test]
+fn set_weighted_qureg_01() {
+    let env = &QuestEnv::new();
+    let qureg1 = &mut Qureg::try_new(1, env).unwrap();
+    init_zero_state(qureg1);
+    let qureg2 = &mut Qureg::try_new(1, env).unwrap();
+    init_zero_state(qureg2);
+    pauli_x(qureg2, 0).unwrap();
+
+    let out = &mut Qureg::try_new(1, env).unwrap();
+    init_zero_state(out);
+
+    let fac1 = Qcomplex::new(SQRT_2.recip(), 0.);
+    let fac2 = Qcomplex::new(SQRT_2.recip(), 0.);
+    let fac_out = Qcomplex::zero();
+
+    set_weighted_qureg(fac1, qureg1, fac2, qureg2, fac_out, out).unwrap();
+}
+
+#[test]
+fn set_weighted_qureg_02() {
+    let env = &QuestEnv::new();
+    let qureg1 = &mut Qureg::try_new(1, env).unwrap();
+    init_zero_state(qureg1);
+    // dimensions are not equal
+    let qureg2 = &mut Qureg::try_new(2, env).unwrap();
+    init_zero_state(qureg2);
+    pauli_x(qureg2, 0).unwrap();
+
+    let out = &mut Qureg::try_new(1, env).unwrap();
+    init_zero_state(out);
+
+    let fac1 = Qcomplex::new(SQRT_2.recip(), 0.);
+    let fac2 = Qcomplex::new(SQRT_2.recip(), 0.);
+    let fac_out = Qcomplex::zero();
+
+    set_weighted_qureg(fac1, qureg1, fac2, qureg2, fac_out, out).unwrap_err();
+}
+
+#[test]
+fn set_weighted_qureg_03() {
+    let env = &QuestEnv::new();
+    let qureg1 = &mut Qureg::try_new(1, env).unwrap();
+    init_zero_state(qureg1);
+    let qureg2 = &mut Qureg::try_new(1, env).unwrap();
+    init_zero_state(qureg2);
+    pauli_x(qureg2, 0).unwrap();
+
+    // dimensions are not equal
+    let out = &mut Qureg::try_new(2, env).unwrap();
+    init_zero_state(out);
+
+    let fac1 = Qcomplex::new(SQRT_2.recip(), 0.);
+    let fac2 = Qcomplex::new(SQRT_2.recip(), 0.);
+    let fac_out = Qcomplex::zero();
+
+    set_weighted_qureg(fac1, qureg1, fac2, qureg2, fac_out, out).unwrap_err();
+}
+
+#[test]
+fn set_weighted_qureg_04() {
+    let env = &QuestEnv::new();
+    let qureg1 = &mut Qureg::try_new(1, env).unwrap();
+    init_zero_state(qureg1);
+    // all quregs should either state vectors of density matrices
+    let qureg2 = &mut Qureg::try_new_density(1, env).unwrap();
+    init_zero_state(qureg2);
+    pauli_x(qureg2, 0).unwrap();
+
+    let out = &mut Qureg::try_new(2, env).unwrap();
+    init_zero_state(out);
+
+    let fac1 = Qcomplex::new(SQRT_2.recip(), 0.);
+    let fac2 = Qcomplex::new(SQRT_2.recip(), 0.);
+    let fac_out = Qcomplex::zero();
+
+    set_weighted_qureg(fac1, qureg1, fac2, qureg2, fac_out, out).unwrap_err();
 }


### PR DESCRIPTION
There are the API functions that still need to be documented:

- [x] `apply_pauli_hamil()`
- [x] `apply_pauli_sum()`
- [x] `apply_trotter_circuit()`
- [x] `multi_controlled_multi_rotate_z()`
- [x] `multi_conrolled_multi_rotate_pauli()`
- [x] `set_weighted_qureg()`

Some functions' signatures have changed.  Those are documented on the `dev` branch.