### PR TITLE
Catch exceptions via std::panic::catch_unwind()

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@
 ## v0.3.5 (??/??/????)
 
 - Implement Sync and Send traits for `QuestEnv` and `Qureg`.
+- Rewrite exception handling using `panic` mechanism. No more global API locks!
+  Our wrapper is now fully concurrent.
 - API breaking changes:
 
   - Move free functions onto `QuestEnv` type:

--- a/README.md
+++ b/README.md
@@ -194,16 +194,14 @@ On failure, QuEST throws exceptions via user-configurable global
 By default, this function prints an error message and aborts, which is
 problematic in a large distributed setup.
 
-We opt for catching all exceptions early. The exception handler is locked during
-an API call. This means that calling QuEST functions is synchronous and should
-be thread-safe, but comes at the expense of being able to run only one QuEST API
-call at the time. Bear in mind, though, that each QuEST function retains access
-to all parallel computation resources available in the system.
+We opt for catching all exceptions early by reimplementing
+`invalidQuESTInputError()` to unwind the stack using Rust's
+[`panic`](https://doc.rust-lang.org/std/panic/index.html) mechanism.
 
-Current implementation returns inside `Result<_, QuestError>` only the first
-exception caught. All subsequent messages reported by QuEST, together with that
-first one, are nevertheless logged as errors. To be able to see them, add a
-logger as a dependency to your crate, e.g.:
+Current implementation returns inside `Result<_, QuestError>` the first
+exception caught. Additionally, all error messages reported by QuEST are logged
+as errors. To be able to see them, add a logger as a dependency to your crate,
+e.g.:
 
 ```sh
 cargo add env_logger

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,5 @@
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug)]
+#[non_exhaustive]
 pub enum QuestError {
     /// An exception thrown by the C library.  From QuEST documentation:
     ///

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1,99 +1,70 @@
 //! Catch exceptions thrown by `QuEST`.
 //!
 //! On failure, `QuEST` throws exceptions via user-configurable global
-//! [`invalidQuESTInputError()`][1]. By default, this function prints an error
+//! [`invalidQuESTInputError()`]. By default, this function prints an error
 //! message and aborts, which is problematic in a large distributed setup. We
-//! opt for catching all exceptions early. The exception handler is locked
-//! during an API call. This means that calling `QuEST` functions is synchronous
-//! and should be thread-safe, but comes at the expense of being able to run
-//! only one `QuEST` API call at the time.
-//!
-//! The present implementation works because `QuEST`'s
-//! `invalidQuESTInputError()` is synchronous and *all* `QuEST` API calls from
-//! us that can potentially throw an exception are wrapped with
-//! `catch_quest_exception()`. This way we ensure the calls are synchronous and
-//! all exceptions have been thrown already when it's time for us to scoop them.
+//! opt for catching all exceptions early.
 //!
 //! This is an internal module that doesn't contain any useful user interface.
 //!
-//! [1]: https://quest-kit.github.io/QuEST/group__debug.html#ga51a64b05d31ef9bcf6a63ce26c0092db
+//! [`invalidQuESTInputError()`]: https://quest-kit.github.io/QuEST/group__debug.html#ga51a64b05d31ef9bcf6a63ce26c0092db
 
 use std::{
     ffi::{
         c_char,
         CStr,
     },
-    panic::UnwindSafe,
+    panic::{
+        self,
+        UnwindSafe,
+    },
 };
 
 use super::QuestError;
 
 /// Report error in a `QuEST` API call.
 ///
-/// This function is called by `QuEST` whenever an error occurs.  We redefine it
-/// to put the error message and site reported into a thread-safe global
-/// storage, instead of just aborting.
+/// This function is called by `QuEST` whenever an error occurs.
+/// We redefine it to put the error message and site reported into
+/// `QuestError::InvalidQuESTInputError` and start unwinding the stack.  The
+/// function `catch_quest_exception()` should be able to catch it.
 ///
 /// # Panics
 ///
 /// This function will panic if strings returned by `QuEST` are not properly
-/// formatted (null terminated) C strings, or if the channel used for passing
-/// error messages gets disconnected.
+/// formatted (null terminated) C strings.
 #[allow(non_snake_case)]
 #[no_mangle]
 unsafe extern "C" fn invalidQuESTInputError(
     errMsg: *const c_char,
     errFunc: *const c_char,
 ) {
-    let err_msg = unsafe { CStr::from_ptr(errMsg) }.to_str().unwrap();
-    let err_func = unsafe { CStr::from_ptr(errFunc) }.to_str().unwrap();
+    // SAFETY: errMsg and errFunc are always non-null as a result of
+    // a call to QuEST's function: QuESTAssert()
+    let err_msg = unsafe { CStr::from_ptr(errMsg) }.to_str().expect(
+        "String (errMsg) returned by QuEST should be properly formatted",
+    );
+    let err_func = unsafe { CStr::from_ptr(errFunc) }.to_str().expect(
+        "String (errFunc) returned by QuEST should be properly formatted",
+    );
+    log::error!("QueST Error in function {err_func}: {err_msg}");
 
-    std::panic::resume_unwind(Box::new(QuestError::InvalidQuESTInputError {
+    panic::resume_unwind(Box::new(QuestError::InvalidQuESTInputError {
         err_msg:  err_msg.to_owned(),
         err_func: err_func.to_owned(),
     }));
-
-    // log::error!("QueST Error in function {err_func}: {err_msg}");
 }
 
 /// Execute a call to `QuEST` API and catch exceptions.
-///
-/// This function achieves synchronous execution between threads
-/// by locking the global `QUEST_EXCEPTION_GUARD` each time,
-/// then executing the closure supplied, and checking the global
-/// lock-free storage `QUEST_EXCEPTION_ERROR` for any error messages reported.
-///
-/// This way, interacting with `QuEST` API should stay thread-safe at all times,
-/// at the expense of being able to call only one function at the time.
-/// This is not an undesired property and shouldn't matter much for the overall
-/// performance of the simulation, since each function retains access to all
-/// the parallelism available in the system.
 pub fn catch_quest_exception<T, F>(f: F) -> Result<T, QuestError>
 where
     F: FnOnce() -> T + UnwindSafe,
 {
-    // Lock QuEST to our call
-
-    // Call QuEST API
-    let res = std::panic::catch_unwind(f);
-
-    // // At this point all exceptions have been thrown.
-    // // Get the first exception thrown.  Drain the nonblocking iterator to
-    // leave // it empty for the next call.
-    // let mut err_iter =
-    // QUEST_EXCEPT_ERROR.get_or_init(unbounded).1.try_iter();
-    // let err = err_iter.next();
-    // let _ = err_iter.last();
-
-    // Drop the guard as soon as we don't need it anymore:
-
-    // This might be a little confusing:
-    // If there is Some error, report it;
-    // if there is None, everything's Ok.
-    match res {
-        Err(_boxed) => Err(QuestError::QubitIndexError),
-        Ok(res) => Ok(res),
-    }
+    // Call QuEST API, unwrap the error sent by invalidInputQuestError()
+    panic::catch_unwind(f).map_err(|e| match e.downcast::<QuestError>() {
+        Ok(boxed_err) => *boxed_err,
+        Err(e) => panic::resume_unwind(e),
+    })
 }
 
 #[cfg(test)]

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -23,14 +23,14 @@ use std::{
         c_char,
         CStr,
     },
+    panic::UnwindSafe,
     sync::{
         Mutex,
         OnceLock,
-    }, panic::UnwindSafe,
+    },
 };
 
 use crossbeam::channel::{
-    unbounded,
     Receiver,
     Sender,
 };
@@ -91,12 +91,13 @@ where
     let guard = QUEST_EXCEPT_GUARD.lock().unwrap();
 
     // Call QuEST API
-    let res = std::panic::catch_unwind(|| f());
+    let res = std::panic::catch_unwind(f);
 
     // // At this point all exceptions have been thrown.
-    // // Get the first exception thrown.  Drain the nonblocking iterator to leave
-    // // it empty for the next call.
-    // let mut err_iter = QUEST_EXCEPT_ERROR.get_or_init(unbounded).1.try_iter();
+    // // Get the first exception thrown.  Drain the nonblocking iterator to
+    // leave // it empty for the next call.
+    // let mut err_iter =
+    // QUEST_EXCEPT_ERROR.get_or_init(unbounded).1.try_iter();
     // let err = err_iter.next();
     // let _ = err_iter.last();
 
@@ -107,7 +108,7 @@ where
     // If there is Some error, report it;
     // if there is None, everything's Ok.
     match res {
-        Err(boxed) => Err(QuestError::QubitIndexError),
+        Err(_boxed) => Err(QuestError::QubitIndexError),
         Ok(res) => Ok(res),
     }
 }

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -24,24 +24,9 @@ use std::{
         CStr,
     },
     panic::UnwindSafe,
-    sync::{
-        Mutex,
-        OnceLock,
-    },
-};
-
-use crossbeam::channel::{
-    Receiver,
-    Sender,
 };
 
 use super::QuestError;
-
-static QUEST_EXCEPT_GUARD: Mutex<()> = Mutex::new(());
-static QUEST_EXCEPT_ERROR: OnceLock<(
-    Sender<QuestError>,
-    Receiver<QuestError>,
-)> = OnceLock::new();
 
 /// Report error in a `QuEST` API call.
 ///
@@ -88,7 +73,6 @@ where
     F: FnOnce() -> T + UnwindSafe,
 {
     // Lock QuEST to our call
-    let guard = QUEST_EXCEPT_GUARD.lock().unwrap();
 
     // Call QuEST API
     let res = std::panic::catch_unwind(f);
@@ -102,7 +86,6 @@ where
     // let _ = err_iter.last();
 
     // Drop the guard as soon as we don't need it anymore:
-    drop(guard);
 
     // This might be a little confusing:
     // If there is Some error, report it;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2222,52 +2222,52 @@ pub fn calc_prob_of_outcome(
     })
 }
 
-/// Calculate probabilities of every outcome of the sub-register.
-///
-/// # Examples
-///
-/// ```rust
-/// # use quest_bind::*;
-/// let env = &QuestEnv::new();
-/// let qureg = &mut Qureg::try_new(3, env).unwrap();
-/// init_zero_state(qureg);
-///
-/// let qubits = &[1, 2];
-/// let outcome_probs = &mut vec![0.; 4];
-/// calc_prob_of_all_outcomes(outcome_probs, qureg, qubits).unwrap();
-/// assert_eq!(outcome_probs, &vec![1., 0., 0., 0.]);
-/// ```
-///
-/// See [QuEST API] for more information.
-///
-/// # Panics
-///
-/// This function will panic if
-/// `outcome_probs.len() < num_qubits as usize`
-///
-/// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
-#[allow(clippy::cast_sign_loss)]
-pub fn calc_prob_of_all_outcomes(
-    outcome_probs: &mut [Qreal],
-    qureg: &Qureg<'_>,
-    qubits: &[i32],
-) -> Result<(), QuestError> {
-    let num_qubits = qubits.len() as i32;
-    if num_qubits > qureg.num_qubits_represented()
-        || outcome_probs.len() < (1 << num_qubits)
-    {
-        return Err(QuestError::ArrayLengthError);
-    }
+// /// Calculate probabilities of every outcome of the sub-register.
+// ///
+// /// # Examples
+// ///
+// /// ```rust
+// /// # use quest_bind::*;
+// /// let env = &QuestEnv::new();
+// /// let qureg = &mut Qureg::try_new(3, env).unwrap();
+// /// init_zero_state(qureg);
+// ///
+// /// let qubits = &[1, 2];
+// /// let outcome_probs = &mut vec![0.; 4];
+// /// calc_prob_of_all_outcomes(outcome_probs, qureg, qubits).unwrap();
+// /// assert_eq!(outcome_probs, &vec![1., 0., 0., 0.]);
+// /// ```
+// ///
+// /// See [QuEST API] for more information.
+// ///
+// /// # Panics
+// ///
+// /// This function will panic if
+// /// `outcome_probs.len() < num_qubits as usize`
+// ///
+// /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
+// #[allow(clippy::cast_sign_loss)]
+// pub fn calc_prob_of_all_outcomes(
+//     outcome_probs: &mut [Qreal],
+//     qureg: &Qureg<'_>,
+//     qubits: &[i32],
+// ) -> Result<(), QuestError> {
+//     let num_qubits = qubits.len() as i32;
+//     if num_qubits > qureg.num_qubits_represented()
+//         || outcome_probs.len() < (1 << num_qubits)
+//     {
+//         return Err(QuestError::ArrayLengthError);
+//     }
 
-    catch_quest_exception(|| unsafe {
-        ffi::calcProbOfAllOutcomes(
-            outcome_probs.as_mut_ptr(),
-            qureg.reg,
-            qubits.as_ptr(),
-            num_qubits,
-        );
-    })
-}
+//     catch_quest_exception(|| unsafe {
+//         ffi::calcProbOfAllOutcomes(
+//             outcome_probs.as_mut_ptr(),
+//             qureg.reg,
+//             qubits.as_ptr(),
+//             num_qubits,
+//         );
+//     })
+// }
 
 /// Updates `qureg` to be consistent with measuring qubit in the given outcome.
 ///
@@ -2332,45 +2332,45 @@ pub fn measure(
     catch_quest_exception(|| unsafe { ffi::measure(qureg.reg, measure_qubit) })
 }
 
-/// Measures a single qubit, collapsing it randomly to 0 or 1
-///
-/// Additionally, the function gives the probability of that outcome.
-///
-/// # Examples
-///
-/// ```rust
-/// # use quest_bind::*;
-/// let env = &QuestEnv::new();
-/// let qureg = &mut Qureg::try_new(2, env).unwrap();
-///
-/// // Prepare an entangled state `|00> + |11>`
-/// init_zero_state(qureg);
-/// hadamard(qureg, 0).and(controlled_not(qureg, 0, 1)).unwrap();
-///
-/// // Qubits are entangled now
-/// let prob = &mut -1.;
-/// let outcome1 = measure_with_stats(qureg, 0, prob).unwrap();
-/// assert!((*prob - 0.5).abs() < EPSILON);
-///
-/// let outcome2 = measure_with_stats(qureg, 1, prob).unwrap();
-/// assert!((*prob - 1.).abs() < EPSILON);
-///
-/// assert_eq!(outcome1, outcome2);
-/// ```
-///
-/// See [QuEST API] for more information.
-///
-/// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
-pub fn measure_with_stats(
-    qureg: &mut Qureg<'_>,
-    measure_qubit: i32,
-    outcome_prob: &mut Qreal,
-) -> Result<i32, QuestError> {
-    catch_quest_exception(|| unsafe {
-        let outcome_prob_ptr = outcome_prob as *mut _;
-        ffi::measureWithStats(qureg.reg, measure_qubit, outcome_prob_ptr)
-    })
-}
+// /// Measures a single qubit, collapsing it randomly to 0 or 1
+// ///
+// /// Additionally, the function gives the probability of that outcome.
+// ///
+// /// # Examples
+// ///
+// /// ```rust
+// /// # use quest_bind::*;
+// /// let env = &QuestEnv::new();
+// /// let qureg = &mut Qureg::try_new(2, env).unwrap();
+// ///
+// /// // Prepare an entangled state `|00> + |11>`
+// /// init_zero_state(qureg);
+// /// hadamard(qureg, 0).and(controlled_not(qureg, 0, 1)).unwrap();
+// ///
+// /// // Qubits are entangled now
+// /// let prob = &mut -1.;
+// /// let outcome1 = measure_with_stats(qureg, 0, prob).unwrap();
+// /// assert!((*prob - 0.5).abs() < EPSILON);
+// ///
+// /// let outcome2 = measure_with_stats(qureg, 1, prob).unwrap();
+// /// assert!((*prob - 1.).abs() < EPSILON);
+// ///
+// /// assert_eq!(outcome1, outcome2);
+// /// ```
+// ///
+// /// See [QuEST API] for more information.
+// ///
+// /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
+// pub fn measure_with_stats(
+//     qureg: &mut Qureg<'_>,
+//     measure_qubit: i32,
+//     outcome_prob: &mut Qreal,
+// ) -> Result<i32, QuestError> {
+//     catch_quest_exception(|| unsafe {
+//         let outcome_prob_ptr = outcome_prob as *mut _;
+//         ffi::measureWithStats(qureg.reg, measure_qubit, outcome_prob_ptr)
+//     })
+// }
 
 /// Computes the inner product of two equal-size state vectors.
 ///
@@ -2428,58 +2428,58 @@ pub fn calc_density_inner_product(
     })
 }
 
-/// Seed the random number generator.
-///
-/// Seeds the random number generator with the (master node) current time and
-/// process ID.
-///
-/// # Examples
-///
-/// ```rust
-/// # use quest_bind::*;
-/// let env = &mut QuestEnv::new();
-///
-/// seed_quest_default(env);
-/// ```
-///
-/// See [QuEST API] for more information.
-///
-/// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
-pub fn seed_quest_default(env: &mut QuestEnv) {
-    catch_quest_exception(|| unsafe {
-        let env_ptr = std::ptr::addr_of_mut!(env.0);
-        ffi::seedQuESTDefault(env_ptr);
-    })
-    .expect("seed_quest_default should always succeed");
-}
+// /// Seed the random number generator.
+// ///
+// /// Seeds the random number generator with the (master node) current time and
+// /// process ID.
+// ///
+// /// # Examples
+// ///
+// /// ```rust
+// /// # use quest_bind::*;
+// /// let env = &mut QuestEnv::new();
+// ///
+// /// seed_quest_default(env);
+// /// ```
+// ///
+// /// See [QuEST API] for more information.
+// ///
+// /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
+// pub fn seed_quest_default(env: &mut QuestEnv) {
+//     catch_quest_exception(|| unsafe {
+//         let env_ptr = std::ptr::addr_of_mut!(env.0);
+//         ffi::seedQuESTDefault(env_ptr);
+//     })
+//     .expect("seed_quest_default should always succeed");
+// }
 
-/// Seeds the random number generator with a custom array of key(s).
-///
-/// # Examples
-///
-/// ```rust
-/// # use quest_bind::*;
-/// let env = &mut QuestEnv::new();
-///
-/// seed_quest(env, &[1, 2, 3]);
-/// ```
-///
-/// See [QuEST API] for more information.
-///
-/// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
-pub fn seed_quest(
-    env: &mut QuestEnv,
-    seed_array: &[u64],
-) {
-    let num_seeds = seed_array.len() as i32;
-    // QuEST's function signature is `c_ulong`. Let's use u64 for now...
-    catch_quest_exception(|| unsafe {
-        let env_ptr = std::ptr::addr_of_mut!(env.0);
-        let seed_array_ptr = seed_array.as_ptr();
-        ffi::seedQuEST(env_ptr, seed_array_ptr, num_seeds);
-    })
-    .expect("seed_quest should always succeed");
-}
+// /// Seeds the random number generator with a custom array of key(s).
+// ///
+// /// # Examples
+// ///
+// /// ```rust
+// /// # use quest_bind::*;
+// /// let env = &mut QuestEnv::new();
+// ///
+// /// seed_quest(env, &[1, 2, 3]);
+// /// ```
+// ///
+// /// See [QuEST API] for more information.
+// ///
+// /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
+// pub fn seed_quest(
+//     env: &mut QuestEnv,
+//     seed_array: &[u64],
+// ) {
+//     let num_seeds = seed_array.len() as i32;
+//     // QuEST's function signature is `c_ulong`. Let's use u64 for now...
+//     catch_quest_exception(|| unsafe {
+//         let env_ptr = std::ptr::addr_of_mut!(env.0);
+//         let seed_array_ptr = seed_array.as_ptr();
+//         ffi::seedQuEST(env_ptr, seed_array_ptr, num_seeds);
+//     })
+//     .expect("seed_quest should always succeed");
+// }
 
 /// Obtain the seeds presently used in random number generation.
 ///

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -884,22 +884,22 @@ fn calc_prob_of_outcome_01() {
     let _ = calc_prob_of_outcome(qureg, 4, 0).unwrap_err();
 }
 
-#[test]
-fn calc_prob_of_all_outcomes_01() {
-    let env = &QuestEnv::new();
-    let qureg = &mut Qureg::try_new(3, env).unwrap();
-    init_zero_state(qureg);
+// #[test]
+// fn calc_prob_of_all_outcomes_01() {
+//     let env = &QuestEnv::new();
+//     let qureg = &mut Qureg::try_new(3, env).unwrap();
+//     init_zero_state(qureg);
 
-    let outcome_probs = &mut vec![0.; 4];
-    calc_prob_of_all_outcomes(outcome_probs, qureg, &[1, 2]).unwrap();
-    calc_prob_of_all_outcomes(outcome_probs, qureg, &[0, 1]).unwrap();
-    calc_prob_of_all_outcomes(outcome_probs, qureg, &[0, 2]).unwrap();
+//     let outcome_probs = &mut vec![0.; 4];
+//     calc_prob_of_all_outcomes(outcome_probs, qureg, &[1, 2]).unwrap();
+//     calc_prob_of_all_outcomes(outcome_probs, qureg, &[0, 1]).unwrap();
+//     calc_prob_of_all_outcomes(outcome_probs, qureg, &[0, 2]).unwrap();
 
-    calc_prob_of_all_outcomes(outcome_probs, qureg, &[1, 2, 3]).unwrap_err();
-    calc_prob_of_all_outcomes(outcome_probs, qureg, &[0, 0]).unwrap_err();
-    calc_prob_of_all_outcomes(outcome_probs, qureg, &[4, 0]).unwrap_err();
-    calc_prob_of_all_outcomes(outcome_probs, qureg, &[0, -1]).unwrap_err();
-}
+//     calc_prob_of_all_outcomes(outcome_probs, qureg, &[1, 2, 3]).unwrap_err();
+//     calc_prob_of_all_outcomes(outcome_probs, qureg, &[0, 0]).unwrap_err();
+//     calc_prob_of_all_outcomes(outcome_probs, qureg, &[4, 0]).unwrap_err();
+//     calc_prob_of_all_outcomes(outcome_probs, qureg, &[0, -1]).unwrap_err();
+// }
 
 #[test]
 fn collapse_to_outcome_01() {
@@ -932,20 +932,20 @@ fn measure_01() {
     let _ = measure(qureg, 3).unwrap_err();
 }
 
-#[test]
-fn measure_with_stats_01() {
-    let env = &QuestEnv::new();
-    let qureg = &mut Qureg::try_new(2, env).unwrap();
+// #[test]
+// fn measure_with_stats_01() {
+//     let env = &QuestEnv::new();
+//     let qureg = &mut Qureg::try_new(2, env).unwrap();
 
-    // Prepare a triplet state `|00> + |11>`
-    init_zero_state(qureg);
+//     // Prepare a triplet state `|00> + |11>`
+//     init_zero_state(qureg);
 
-    let prob = &mut -1.;
-    let _ = measure_with_stats(qureg, 0, prob).unwrap();
-    let _ = measure_with_stats(qureg, 1, prob).unwrap();
-    let _ = measure_with_stats(qureg, -1, prob).unwrap_err();
-    let _ = measure_with_stats(qureg, 3, prob).unwrap_err();
-}
+//     let prob = &mut -1.;
+//     let _ = measure_with_stats(qureg, 0, prob).unwrap();
+//     let _ = measure_with_stats(qureg, 1, prob).unwrap();
+//     let _ = measure_with_stats(qureg, -1, prob).unwrap_err();
+//     let _ = measure_with_stats(qureg, 3, prob).unwrap_err();
+// }
 
 #[test]
 fn calc_inner_product_01() {
@@ -1021,16 +1021,16 @@ fn get_quest_seeds_01() {
     assert!(!seeds.is_empty());
 }
 
-#[test]
-fn get_quest_seeds_02() {
-    let env = &mut QuestEnv::new();
-    let seed_array = &[0, 1, 2, 3];
-    seed_quest(env, seed_array);
-    let seeds = get_quest_seeds(env);
+// #[test]
+// fn get_quest_seeds_02() {
+//     let env = &mut QuestEnv::new();
+//     let seed_array = &[0, 1, 2, 3];
+//     seed_quest(env, seed_array);
+//     let seeds = get_quest_seeds(env);
 
-    assert!(!seeds.is_empty());
-    assert_eq!(seed_array, seeds);
-}
+//     assert!(!seeds.is_empty());
+//     assert_eq!(seed_array, seeds);
+// }
 
 #[test]
 fn start_recording_qasm_01() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1021,16 +1021,16 @@ fn get_quest_seeds_01() {
     assert!(!seeds.is_empty());
 }
 
-// #[test]
-// fn get_quest_seeds_02() {
-//     let env = &mut QuestEnv::new();
-//     let seed_array = &[0, 1, 2, 3];
-//     seed_quest(env, seed_array);
-//     let seeds = get_quest_seeds(env);
+#[test]
+fn get_quest_seeds_02() {
+    let env = &mut QuestEnv::new();
+    let seed_array = &[0, 1, 2, 3];
+    seed_quest(env, seed_array);
+    let seeds = get_quest_seeds(env);
 
-//     assert!(!seeds.is_empty());
-//     assert_eq!(seed_array, seeds);
-// }
+    assert!(!seeds.is_empty());
+    assert_eq!(seed_array, seeds);
+}
 
 #[test]
 fn start_recording_qasm_01() {


### PR DESCRIPTION
No locks or message passing.  Fully concurrent QuEST wrapper!

- [x] Update functions using types that don't implement UnwindSafe
- [x] Reenable problematic tests
- [x] Update examples
- [x] Update Readme (Handling Exceptions)
- [x] Update exceptions.rs docs