### PR TITLE
Remove spurious checks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,9 @@
 
 - Implement Sync and Send traits for `QuestEnv` and `Qureg`.
 - Rewrite exception handling using `panic` mechanism. No more global API locks!
-  Our wrapper is now fully concurrent.
+  Our wrapper is now fully concurrent and much faster.
+- Remove spurious checks that existed due to imperfect error catching.
+
 - API breaking changes:
 
   - Move free functions onto `QuestEnv` type:
@@ -18,6 +20,12 @@
     - `get_num_amps()`
     - `report_state()`
     - `report_state_to_screen()` (signature change)
+
+  - Remove `QuestError` variants not needed anymore:
+
+    - `QubitIndexError`
+    - `NotDensityMatrix`
+    - `NegativeProbability`
 
 ## v0.3.4 (29/07/2023)
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,7 +23,4 @@ pub enum QuestError {
     NulError(std::ffi::NulError),
     IntoStringError(std::ffi::IntoStringError),
     ArrayLengthError,
-    QubitIndexError,
-    NotDensityMatrix,
-    NegativeProbability,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3184,15 +3184,6 @@ pub fn multi_state_controlled_unitary(
     u: &ComplexMatrix2,
 ) -> Result<(), QuestError> {
     let num_control_qubits = control_qubits.len() as i32;
-    let num_qubits_rep = qureg.num_qubits_represented();
-    for &idx in control_qubits {
-        if idx >= num_qubits_rep {
-            return Err(QuestError::QubitIndexError);
-        }
-    }
-    if target_qubit >= qureg.num_qubits_represented() || target_qubit < 0 {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::multiStateControlledUnitary(
             qureg.reg,
@@ -3234,10 +3225,6 @@ pub fn multi_rotate_z(
     angle: Qreal,
 ) -> Result<(), QuestError> {
     let num_qubits = qubits.len() as i32;
-    if num_qubits > qureg.num_qubits_represented() {
-        return Err(QuestError::ArrayLengthError);
-    }
-
     catch_quest_exception(|| unsafe {
         ffi::multiRotateZ(qureg.reg, qubits.as_ptr(), num_qubits, angle);
     })
@@ -3275,18 +3262,6 @@ pub fn multi_rotate_pauli(
     angle: Qreal,
 ) -> Result<(), QuestError> {
     let num_targets = target_qubits.len() as i32;
-    let num_qubits_rep = qureg.num_qubits_represented();
-    if num_targets > num_qubits_rep {
-        return Err(QuestError::ArrayLengthError);
-    }
-    for &idx in target_qubits {
-        if idx >= num_qubits_rep || idx < 0 {
-            return Err(QuestError::QubitIndexError);
-        }
-    }
-    if target_paulis.len() < target_qubits.len() {
-        return Err(QuestError::ArrayLengthError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::multiRotatePauli(
             qureg.reg,
@@ -3395,9 +3370,6 @@ pub fn multi_controlled_multi_rotate_pauli(
 ) -> Result<(), QuestError> {
     let num_controls = control_qubits.len() as i32;
     let num_targets = target_qubits.len() as i32;
-    if target_paulis.len() != target_qubits.len() {
-        return Err(QuestError::ArrayLengthError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::multiControlledMultiRotatePauli(
             qureg.reg,
@@ -3443,14 +3415,6 @@ pub fn calc_expec_pauli_prod(
     workspace: &mut Qureg<'_>,
 ) -> Result<Qreal, QuestError> {
     let num_targets = target_qubits.len() as i32;
-    if pauli_codes.len() as i32 != num_targets {
-        return Err(QuestError::ArrayLengthError);
-    }
-    for &idx in target_qubits {
-        if idx < 0 || idx > qureg.num_qubits_represented() {
-            return Err(QuestError::QubitIndexError);
-        }
-    }
     catch_quest_exception(|| unsafe {
         ffi::calcExpecPauliProd(
             qureg.reg,
@@ -3594,12 +3558,6 @@ pub fn two_qubit_unitary(
     target_qubit2: i32,
     u: &ComplexMatrix4,
 ) -> Result<(), QuestError> {
-    let num_qubits_rep = qureg.num_qubits_represented();
-    if !((0..num_qubits_rep).contains(&target_qubit1)
-        && (0..num_qubits_rep).contains(&target_qubit2))
-    {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::twoQubitUnitary(qureg.reg, target_qubit1, target_qubit2, u.0);
     })
@@ -3657,13 +3615,6 @@ pub fn controlled_two_qubit_unitary(
     target_qubit2: i32,
     u: &ComplexMatrix4,
 ) -> Result<(), QuestError> {
-    let num_qubits_rep = qureg.num_qubits_represented();
-    if !((0..num_qubits_rep).contains(&target_qubit1)
-        && (0..num_qubits_rep).contains(&target_qubit2)
-        && (0..num_qubits_rep).contains(&control_qubit))
-    {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::controlledTwoQubitUnitary(
             qureg.reg,
@@ -3728,18 +3679,7 @@ pub fn multi_controlled_two_qubit_unitary(
     target_qubit2: i32,
     u: &ComplexMatrix4,
 ) -> Result<(), QuestError> {
-    let num_qubits_rep = qureg.num_qubits_represented();
     let num_control_qubits = control_qubits.len() as i32;
-    for idx in control_qubits {
-        if !(0..num_qubits_rep).contains(idx) {
-            return Err(QuestError::QubitIndexError);
-        }
-    }
-    if !((0..num_qubits_rep).contains(&target_qubit1)
-        && (0..num_qubits_rep).contains(&target_qubit2))
-    {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::multiControlledTwoQubitUnitary(
             qureg.reg,
@@ -3792,11 +3732,6 @@ pub fn multi_qubit_unitary(
     u: &ComplexMatrixN,
 ) -> Result<(), QuestError> {
     let num_targs = targs.len() as i32;
-    for &idx in targs {
-        if idx < 0 || idx >= qureg.num_qubits_represented() {
-            return Err(QuestError::QubitIndexError);
-        }
-    }
     catch_quest_exception(|| unsafe {
         ffi::multiQubitUnitary(qureg.reg, targs.as_ptr(), num_targs, u.0);
     })
@@ -3846,15 +3781,7 @@ pub fn controlled_multi_qubit_unitary(
     targs: &[i32],
     u: &ComplexMatrixN,
 ) -> Result<(), QuestError> {
-    if ctrl < 0 || ctrl >= qureg.num_qubits_represented() {
-        return Err(QuestError::QubitIndexError);
-    }
     let num_targs = targs.len() as i32;
-    for &idx in targs {
-        if idx < 0 || idx >= qureg.num_qubits_represented() {
-            return Err(QuestError::QubitIndexError);
-        }
-    }
     catch_quest_exception(|| unsafe {
         ffi::controlledMultiQubitUnitary(
             qureg.reg,
@@ -3911,19 +3838,8 @@ pub fn multi_controlled_multi_qubit_unitary(
     targs: &[i32],
     u: &ComplexMatrixN,
 ) -> Result<(), QuestError> {
-    let num_qubits_rep = qureg.num_qubits_represented();
     let num_ctrls = ctrls.len() as i32;
-    for &idx in ctrls {
-        if idx < 0 || idx >= num_qubits_rep {
-            return Err(QuestError::QubitIndexError);
-        }
-    }
     let num_targs = targs.len() as i32;
-    for &idx in targs {
-        if idx < 0 || idx >= num_qubits_rep {
-            return Err(QuestError::QubitIndexError);
-        }
-    }
     catch_quest_exception(|| unsafe {
         ffi::multiControlledMultiQubitUnitary(
             qureg.reg,
@@ -3965,15 +3881,7 @@ pub fn mix_kraus_map(
     target: i32,
     ops: &[&ComplexMatrix2],
 ) -> Result<(), QuestError> {
-    let num_qubits_rep = qureg.num_qubits_represented();
-    if target < 0 || target >= num_qubits_rep {
-        return Err(QuestError::QubitIndexError);
-    }
-
     let num_ops = ops.len() as i32;
-    if !(1..=4).contains(&num_ops) {
-        return Err(QuestError::ArrayLengthError);
-    }
     let ops_inner = ops.iter().map(|x| x.0).collect::<Vec<_>>();
     catch_quest_exception(|| unsafe {
         ffi::mixKrausMap(qureg.reg, target, ops_inner.as_ptr(), num_ops);
@@ -4024,17 +3932,7 @@ pub fn mix_two_qubit_kraus_map(
     target2: i32,
     ops: &[&ComplexMatrix4],
 ) -> Result<(), QuestError> {
-    let num_qubits_rep = qureg.num_qubits_represented();
-    if target1 < 0 || target1 >= num_qubits_rep {
-        return Err(QuestError::QubitIndexError);
-    }
-    if target2 < 0 || target2 >= num_qubits_rep {
-        return Err(QuestError::QubitIndexError);
-    }
     let num_ops = ops.len() as i32;
-    if !(1..=16).contains(&num_ops) {
-        return Err(QuestError::ArrayLengthError);
-    }
     let ops_inner = ops.iter().map(|x| x.0).collect::<Vec<_>>();
     catch_quest_exception(|| unsafe {
         ffi::mixTwoQubitKrausMap(
@@ -4091,17 +3989,8 @@ pub fn mix_multi_qubit_kraus_map(
     targets: &[i32],
     ops: &[&ComplexMatrixN],
 ) -> Result<(), QuestError> {
-    let num_qubits_rep = qureg.num_qubits_represented();
     let num_targets = targets.len() as i32;
-    for &target in targets {
-        if target < 0 || target >= num_qubits_rep {
-            return Err(QuestError::QubitIndexError);
-        }
-    }
     let num_ops = ops.len() as i32;
-    if !(1..=1 << (2 * num_qubits_rep)).contains(&num_ops) {
-        return Err(QuestError::ArrayLengthError);
-    }
     let ops_inner = ops.iter().map(|x| x.0).collect::<Vec<_>>();
     catch_quest_exception(|| unsafe {
         ffi::mixMultiQubitKrausMap(
@@ -4145,9 +4034,6 @@ pub fn mix_nontp_kraus_map(
     ops: &[&ComplexMatrix2],
 ) -> Result<(), QuestError> {
     let num_ops = ops.len() as i32;
-    if !(0..qureg.num_qubits_represented()).contains(&target) {
-        return Err(QuestError::QubitIndexError);
-    }
     let ops_inner = ops.iter().map(|x| x.0).collect::<Vec<_>>();
     catch_quest_exception(|| unsafe {
         ffi::mixNonTPKrausMap(qureg.reg, target, ops_inner.as_ptr(), num_ops);
@@ -4199,17 +4085,7 @@ pub fn mix_nontp_two_qubit_kraus_map(
     target2: i32,
     ops: &[&ComplexMatrix4],
 ) -> Result<(), QuestError> {
-    let num_qubits_rep = qureg.num_qubits_represented();
-    if target1 < 0 || target1 >= num_qubits_rep {
-        return Err(QuestError::QubitIndexError);
-    }
-    if target2 < 0 || target2 >= num_qubits_rep {
-        return Err(QuestError::QubitIndexError);
-    }
     let num_ops = ops.len() as i32;
-    if !(1..=16).contains(&num_ops) {
-        return Err(QuestError::ArrayLengthError);
-    }
     let ops_inner = ops.iter().map(|x| x.0).collect::<Vec<_>>();
     catch_quest_exception(|| unsafe {
         ffi::mixNonTPTwoQubitKrausMap(
@@ -4267,17 +4143,8 @@ pub fn mix_nontp_multi_qubit_kraus_map(
     targets: &[i32],
     ops: &[&ComplexMatrixN],
 ) -> Result<(), QuestError> {
-    let num_qubits_rep = qureg.num_qubits_represented();
     let num_targets = targets.len() as i32;
-    for &target in targets {
-        if target < 0 || target >= num_qubits_rep {
-            return Err(QuestError::QubitIndexError);
-        }
-    }
     let num_ops = ops.len() as i32;
-    if !(1..=1 << (2 * num_qubits_rep)).contains(&num_ops) {
-        return Err(QuestError::ArrayLengthError);
-    }
     let ops_inner = ops.iter().map(|x| x.0).collect::<Vec<_>>();
     catch_quest_exception(|| unsafe {
         ffi::mixNonTPMultiQubitKrausMap(
@@ -4547,9 +4414,6 @@ pub fn apply_matrix2(
     target_qubit: i32,
     u: &ComplexMatrix2,
 ) -> Result<(), QuestError> {
-    if target_qubit >= qureg.num_qubits_represented() || target_qubit < 0 {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::applyMatrix2(qureg.reg, target_qubit, u.0);
     })
@@ -4597,12 +4461,6 @@ pub fn apply_matrix4(
     target_qubit2: i32,
     u: &ComplexMatrix4,
 ) -> Result<(), QuestError> {
-    if target_qubit1 >= qureg.num_qubits_represented() || target_qubit1 < 0 {
-        return Err(QuestError::QubitIndexError);
-    }
-    if target_qubit2 >= qureg.num_qubits_represented() || target_qubit2 < 0 {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::applyMatrix4(qureg.reg, target_qubit1, target_qubit2, u.0);
     })
@@ -4655,15 +4513,6 @@ pub fn apply_matrix_n(
     u: &ComplexMatrixN,
 ) -> Result<(), QuestError> {
     let num_targs = targs.len() as i32;
-    let num_qubits_rep = qureg.num_qubits_represented();
-    if num_targs > num_qubits_rep {
-        return Err(QuestError::ArrayLengthError);
-    }
-    for &idx in targs {
-        if idx < 0 || idx >= num_qubits_rep {
-            return Err(QuestError::QubitIndexError);
-        }
-    }
     catch_quest_exception(|| unsafe {
         ffi::applyMatrixN(qureg.reg, targs.as_ptr(), num_targs, u.0);
     })
@@ -4808,9 +4657,8 @@ pub fn apply_multi_controlled_matrix_n(
 ///
 /// # Errors
 ///
-/// - [`ArrayLengthError`], if the length of `coeffs` is different than that of
-///   `exponents`
 /// - [`InvalidQuESTInputError`]
+///   - if the length of `coeffs` is different than that of  `exponents`
 ///   - if any qubit in `qubits` has an invalid index (i.e. does not satisfy `0
 ///     <= qubit < qureg.num_qubits_represented()`
 ///   - if the elements of `qubits` are not unique
@@ -4845,7 +4693,6 @@ pub fn apply_multi_controlled_matrix_n(
 /// [api-bit-encoding]: crate::BitEncoding
 /// [api-apply-phase-func-overrides]: crate::apply_phase_func_overrides()
 /// [`qureg.num_qubits_represented()`]: crate::Qureg::num_qubits_represented()
-/// [`ArrayLengthError`]: crate::QuestError::ArrayLengthError
 /// [`InvalidQuESTInputError`]: crate::QuestError::InvalidQuESTInputError
 /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
 pub fn apply_phase_func(
@@ -4856,11 +4703,7 @@ pub fn apply_phase_func(
     exponents: &[Qreal],
 ) -> Result<(), QuestError> {
     let num_qubits = qubits.len() as i32;
-    let num_terms = coeffs.len();
-    if exponents.len() != num_terms {
-        return Err(QuestError::ArrayLengthError);
-    }
-    let num_terms = num_terms as i32;
+    let num_terms = coeffs.len() as i32;
     catch_quest_exception(|| unsafe {
         ffi::applyPhaseFunc(
             qureg.reg,
@@ -4917,11 +4760,10 @@ pub fn apply_phase_func(
 ///
 /// # Errors
 ///
-/// - [`ArrayLengthError`],
-///   - if the length of `coeffs` is different than that of `exponents`
+/// - [`InvalidQuESTInputError`],
 ///   - if the length of `override_inds` is different than that of
 ///     `override_phases`
-/// - [`InvalidQuESTInputError`],
+///   - if the length of `coeffs` is different than that of `exponents`
 ///   - if any qubit in `qubits` has an invalid index (i.e. does not satisfy `0
 ///     <= qubit < qureg.num_qubits_represented()`
 ///   - if the elements of `qubits` are not unique
@@ -4971,7 +4813,6 @@ pub fn apply_phase_func(
 ///
 /// [api-apply-phase-func]: crate::apply_phase_func()
 /// [api-bit-encoding]: crate::BitEncoding
-/// [`ArrayLengthError`]: crate::QuestError::ArrayLengthError
 /// [`InvalidQuESTInputError`]: crate::QuestError::InvalidQuESTInputError
 /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
 #[allow(clippy::too_many_arguments)]
@@ -4985,16 +4826,8 @@ pub fn apply_phase_func_overrides(
     override_phases: &[Qreal],
 ) -> Result<(), QuestError> {
     let num_qubits = qubits.len() as i32;
-    let num_terms = coeffs.len();
-    if exponents.len() != num_terms {
-        return Err(QuestError::ArrayLengthError);
-    }
-    let num_terms = num_terms as i32;
-    let num_overrides = override_inds.len();
-    if override_phases.len() != num_overrides {
-        return Err(QuestError::ArrayLengthError);
-    }
-    let num_overrides = num_overrides as i32;
+    let num_terms = coeffs.len() as i32;
+    let num_overrides = override_inds.len() as i32;
     catch_quest_exception(|| unsafe {
         ffi::applyPhaseFuncOverrides(
             qureg.reg,
@@ -5466,11 +5299,11 @@ pub fn apply_full_qft(qureg: &mut Qureg<'_>) {
 ///
 /// # Errors
 ///
-/// - [`ArrayLengthError`], if the length of `qubits` is less than
-///   [`qureg.num_qubits_represented()`]
-/// - [`QubitIndexError`], if any of `qubits` is outside [0,
-///   [`qureg.num_qubits_represented()`]).
-/// - [`InvalidQuESTInputError`], if `qubits` contains any repetitions
+/// - [`InvalidQuESTInputError`],
+///   - if the length of `qubits` is less than
+///     [`qureg.num_qubits_represented()`]
+///   - if any of `qubits` is outside [0, [`qureg.num_qubits_represented()`]).
+///   - if `qubits` contains any repetitions
 ///
 ///
 /// # Examples
@@ -5488,9 +5321,7 @@ pub fn apply_full_qft(qureg: &mut Qureg<'_>) {
 ///
 /// [`apply_full_qft()`]: crate::apply_full_qft()
 /// [`apply_named_phase_func()`]: crate::apply_named_phase_func()
-/// [`ArrayLengthError`]: crate::QuestError::ArrayLengthError
 /// [`InvalidQuESTInputError`]: crate::QuestError::InvalidQuESTInputError
-/// [`QubitIndexError`]: crate::QuestError::QubitIndexError
 /// [`qureg.num_qubits_represented()`]: crate::Qureg::num_qubits_represented()
 /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
 pub fn apply_qft(
@@ -5498,15 +5329,6 @@ pub fn apply_qft(
     qubits: &[i32],
 ) -> Result<(), QuestError> {
     let num_qubits = qubits.len() as i32;
-    let num_qubits_rep = qureg.num_qubits_represented();
-    if num_qubits > num_qubits_rep {
-        return Err(QuestError::ArrayLengthError);
-    }
-    for &idx in qubits {
-        if idx >= num_qubits_rep {
-            return Err(QuestError::QubitIndexError);
-        }
-    }
     catch_quest_exception(|| unsafe {
         ffi::applyQFT(qureg.reg, qubits.as_ptr(), num_qubits);
     })
@@ -5537,9 +5359,8 @@ pub fn apply_qft(
 ///
 /// # Errors
 ///
-/// - [`QubitIndexError`],
-///   - if `qubit` is outside [0, [`qureg.num_qubits_represented()`]).
 /// - [`InvalidQuESTInputError`],
+///   - if `qubit` is outside [0, [`qureg.num_qubits_represented()`]).
 ///   - if `outcome` is not in {0,1}
 ///
 /// # Examples
@@ -5569,9 +5390,6 @@ pub fn apply_projector(
     qubit: i32,
     outcome: i32,
 ) -> Result<(), QuestError> {
-    if qubit >= qureg.num_qubits_represented() || qubit < 0 {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::applyProjector(qureg.reg, qubit, outcome);
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -513,14 +513,6 @@ pub fn multi_controlled_phase_shift(
     angle: Qreal,
 ) -> Result<(), QuestError> {
     let num_control_qubits = control_qubits.len() as i32;
-    if num_control_qubits > qureg.num_qubits_represented() {
-        return Err(QuestError::ArrayLengthError);
-    }
-    for &idx in control_qubits {
-        if idx >= qureg.num_qubits_represented() || idx < 0 {
-            return Err(QuestError::QubitIndexError);
-        }
-    }
     catch_quest_exception(|| unsafe {
         ffi::multiControlledPhaseShift(
             qureg.reg,
@@ -1120,9 +1112,8 @@ pub fn calc_total_prob(qureg: &Qureg<'_>) -> Qreal {
 ///
 /// # Errors
 ///
-/// - [`QubitIndexError`],
-///   - if `target_qubit` is outside [0, [`qureg.num_qubits_represented()`]).
 /// - [`InvalidQuESTInputError`],
+///   - if `target_qubit` is outside [0, [`qureg.num_qubits_represented()`]).
 ///   - if  `alpha`, `beta` don't satisfy: `|alpha|^2 + |beta|^2 = 1`.
 ///
 /// # Examples
@@ -1148,7 +1139,6 @@ pub fn calc_total_prob(qureg: &Qureg<'_>) -> Qreal {
 ///
 /// See [QuEST API] for more information.
 ///
-/// [`QubitIndexError`]: crate::QuestError::QubitIndexError
 /// [`qureg.num_qubits_represented()`]: crate::Qureg::num_qubits_represented()
 /// [`InvalidQuESTInputError`]: crate::QuestError::InvalidQuESTInputError
 /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
@@ -1158,9 +1148,6 @@ pub fn compact_unitary(
     alpha: Qcomplex,
     beta: Qcomplex,
 ) -> Result<(), QuestError> {
-    if target_qubit >= qureg.num_qubits_represented() {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::compactUnitary(qureg.reg, target_qubit, alpha.into(), beta.into());
     })
@@ -1179,9 +1166,8 @@ pub fn compact_unitary(
 ///
 /// # Errors
 ///
-/// - [`QubitIndexError`],
-///   - if `target_qubit` is outside [0, [`qureg.num_qubits_represented()`]).
 /// - [`InvalidQuESTInputError`],
+///   - if `target_qubit` is outside [0, [`qureg.num_qubits_represented()`]).
 ///   - if `u` is not unitary
 ///
 /// # Examples
@@ -1209,7 +1195,6 @@ pub fn compact_unitary(
 ///
 /// See [QuEST API] for more information.
 ///
-/// [`QubitIndexError`]: crate::QuestError::QubitIndexError
 /// [`qureg.num_qubits_represented()`]: crate::Qureg::num_qubits_represented()
 /// [`InvalidQuESTInputError`]: crate::QuestError::InvalidQuESTInputError
 /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
@@ -1218,10 +1203,6 @@ pub fn unitary(
     target_qubit: i32,
     u: &ComplexMatrix2,
 ) -> Result<(), QuestError> {
-    if target_qubit >= qureg.num_qubits_represented() {
-        return Err(QuestError::QubitIndexError);
-    }
-
     catch_quest_exception(|| unsafe {
         ffi::unitary(qureg.reg, target_qubit, u.0);
     })
@@ -1244,8 +1225,8 @@ pub fn unitary(
 ///
 /// # Errors
 ///
-/// - [`QubitIndexError`],  if `rot_qubit` is outside [0,
-///   [`qureg.num_qubits_represented()`]).
+/// - [`InvalidQuESTInputError`],
+///   - if `rot_qubit` is outside [0, [`qureg.num_qubits_represented()`]).
 ///
 /// # Examples
 ///
@@ -1261,16 +1242,13 @@ pub fn unitary(
 /// See [QuEST API] for more information.
 ///
 /// [`qureg.num_qubits_represented()`]: crate::Qureg::num_qubits_represented()
-/// [`QubitIndexError`]: crate::QuestError::QubitIndexError
+/// [`InvalidQuESTInputError`]: crate::QuestError::InvalidQuESTInputError
 /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
 pub fn rotate_x(
     qureg: &mut Qureg<'_>,
     rot_qubit: i32,
     angle: Qreal,
 ) -> Result<(), QuestError> {
-    if rot_qubit >= qureg.num_qubits_represented() || rot_qubit < 0 {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::rotateX(qureg.reg, rot_qubit, angle);
     })
@@ -1293,8 +1271,8 @@ pub fn rotate_x(
 ///
 /// # Errors
 ///
-/// - [`QubitIndexError`],  if `rot_qubit` is outside [0,
-///   [`qureg.num_qubits_represented()`]).
+/// - [`InvalidQuESTInputError`],
+///   - if `rot_qubit` is outside [0, [`qureg.num_qubits_represented()`]).
 ///
 /// # Examples
 ///
@@ -1310,16 +1288,13 @@ pub fn rotate_x(
 /// See [QuEST API] for more information.
 ///
 /// [`qureg.num_qubits_represented()`]: crate::Qureg::num_qubits_represented()
-/// [`QubitIndexError`]: crate::QuestError::QubitIndexError
+/// [`InvalidQuESTInputError`]: crate::QuestError::InvalidQuESTInputError
 /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
 pub fn rotate_y(
     qureg: &mut Qureg<'_>,
     rot_qubit: i32,
     angle: Qreal,
 ) -> Result<(), QuestError> {
-    if rot_qubit >= qureg.num_qubits_represented() || rot_qubit < 0 {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::rotateY(qureg.reg, rot_qubit, angle);
     })
@@ -1342,8 +1317,8 @@ pub fn rotate_y(
 ///
 /// # Errors
 ///
-/// - [`QubitIndexError`],  if `rot_qubit` is outside [0,
-///   [`qureg.num_qubits_represented()`]).
+/// - [`InvalidQuESTInputError`],
+///   - if `rot_qubit` is outside [0, [`qureg.num_qubits_represented()`]).
 ///
 /// # Examples
 ///
@@ -1359,16 +1334,13 @@ pub fn rotate_y(
 /// See [QuEST API] for more information.
 ///
 /// [`qureg.num_qubits_represented()`]: crate::Qureg::num_qubits_represented()
-/// [`QubitIndexError`]: crate::QuestError::QubitIndexError
+/// [`InvalidQuESTInputError`]: crate::QuestError::InvalidQuESTInputError
 /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
 pub fn rotate_z(
     qureg: &mut Qureg<'_>,
     rot_qubit: i32,
     angle: Qreal,
 ) -> Result<(), QuestError> {
-    if rot_qubit >= qureg.num_qubits_represented() || rot_qubit < 0 {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::rotateZ(qureg.reg, rot_qubit, angle);
     })
@@ -1398,9 +1370,6 @@ pub fn rotate_around_axis(
     angle: Qreal,
     axis: &Vector,
 ) -> Result<(), QuestError> {
-    if rot_qubit >= qureg.num_qubits_represented() {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::rotateAroundAxis(qureg.reg, rot_qubit, angle, axis.0);
     })
@@ -1431,11 +1400,6 @@ pub fn controlled_rotate_x(
     target_qubit: i32,
     angle: Qreal,
 ) -> Result<(), QuestError> {
-    if control_qubit >= qureg.num_qubits_represented()
-        || target_qubit >= qureg.num_qubits_represented()
-    {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::controlledRotateX(qureg.reg, control_qubit, target_qubit, angle);
     })
@@ -1466,11 +1430,6 @@ pub fn controlled_rotate_y(
     target_qubit: i32,
     angle: Qreal,
 ) -> Result<(), QuestError> {
-    if control_qubit >= qureg.num_qubits_represented()
-        || target_qubit >= qureg.num_qubits_represented()
-    {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::controlledRotateY(qureg.reg, control_qubit, target_qubit, angle);
     })
@@ -1501,11 +1460,6 @@ pub fn controlled_rotate_z(
     target_qubit: i32,
     angle: Qreal,
 ) -> Result<(), QuestError> {
-    if control_qubit >= qureg.num_qubits_represented()
-        || target_qubit >= qureg.num_qubits_represented()
-    {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::controlledRotateZ(qureg.reg, control_qubit, target_qubit, angle);
     })
@@ -1544,11 +1498,6 @@ pub fn controlled_rotate_around_axis(
     angle: Qreal,
     axis: &Vector,
 ) -> Result<(), QuestError> {
-    if control_qubit >= qureg.num_qubits_represented()
-        || target_qubit >= qureg.num_qubits_represented()
-    {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::controlledRotateAroundAxis(
             qureg.reg,
@@ -1584,9 +1533,9 @@ pub fn controlled_rotate_around_axis(
 ///
 /// # Errors
 ///
-/// - [`QubitIndexError`], if either `target_qubit` or `control_qubit` is
-///   outside [0, [`qureg.num_qubits_represented()`]).
 /// - [`InvalidQuESTInputError`],
+///   - if either `target_qubit` or `control_qubit` is outside [0,
+///     [`qureg.num_qubits_represented()`]).
 ///   - if `control_qubits` and `target_qubit` are equal
 ///   - if  `alpha`, `beta` don't satisfy: `|alpha|^2 + |beta|^2 = 1`.
 ///
@@ -1606,7 +1555,6 @@ pub fn controlled_rotate_around_axis(
 ///
 /// See [QuEST API] for more information.
 ///
-/// [`QubitIndexError`]: crate::QuestError::QubitIndexError
 /// [`qureg.num_qubits_represented()`]: crate::Qureg::num_qubits_represented()
 /// [`InvalidQuESTInputError`]: crate::QuestError::InvalidQuESTInputError
 /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
@@ -1617,11 +1565,6 @@ pub fn controlled_compact_unitary(
     alpha: Qcomplex,
     beta: Qcomplex,
 ) -> Result<(), QuestError> {
-    if control_qubit >= qureg.num_qubits_represented()
-        || target_qubit >= qureg.num_qubits_represented()
-    {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::controlledCompactUnitary(
             qureg.reg,
@@ -1647,9 +1590,9 @@ pub fn controlled_compact_unitary(
 ///
 /// # Errors
 ///
-/// - [`QubitIndexError`], if either `target_qubit` or `control_qubit` is
-///   outside [0, [`qureg.num_qubits_represented()`]).
 /// - [`InvalidQuESTInputError`],
+///   - if either `target_qubit` or `control_qubit` is outside [0,
+///    [`qureg.num_qubits_represented()`]).
 ///   - if `control_qubits` and `target_qubit` are equal
 ///   - if `u` is not unitary
 ///
@@ -1671,7 +1614,6 @@ pub fn controlled_compact_unitary(
 ///
 /// See [QuEST API] for more information.
 ///
-/// [`QubitIndexError`]: crate::QuestError::QubitIndexError
 /// [`qureg.num_qubits_represented()`]: crate::Qureg::num_qubits_represented()
 /// [`InvalidQuESTInputError`]: crate::QuestError::InvalidQuESTInputError
 /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
@@ -1681,11 +1623,6 @@ pub fn controlled_unitary(
     target_qubit: i32,
     u: &ComplexMatrix2,
 ) -> Result<(), QuestError> {
-    if control_qubit >= qureg.num_qubits_represented()
-        || target_qubit >= qureg.num_qubits_represented()
-    {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::controlledUnitary(qureg.reg, control_qubit, target_qubit, u.0);
     })
@@ -1707,9 +1644,9 @@ pub fn controlled_unitary(
 ///
 /// # Errors
 ///
-/// - [`QubitIndexError`], if `target_qubit` or any of `control_qubits` is
-///   outside [0, [`qureg.num_qubits_represented()`]).
 /// - [`InvalidQuESTInputError`],
+///   - if `target_qubit` or any of `control_qubits` is outside [0,
+///     [`qureg.num_qubits_represented()`]).
 ///   - if any qubit in `control_qubits` is repeated
 ///   - if `control_qubits` contains `target_qubit`
 ///   - if `u` is not unitary
@@ -1732,7 +1669,6 @@ pub fn controlled_unitary(
 ///
 /// See [QuEST API] for more information.
 ///
-/// [`QubitIndexError`]: crate::QuestError::QubitIndexError
 /// [`qureg.num_qubits_represented()`]: crate::Qureg::num_qubits_represented()
 /// [`InvalidQuESTInputError`]: crate::QuestError::InvalidQuESTInputError
 /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
@@ -1743,11 +1679,6 @@ pub fn multi_controlled_unitary(
     u: &ComplexMatrix2,
 ) -> Result<(), QuestError> {
     let num_control_qubits = control_qubits.len() as i32;
-    if num_control_qubits >= qureg.num_qubits_represented()
-        || target_qubit >= qureg.num_qubits_represented()
-    {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::multiControlledUnitary(
             qureg.reg,
@@ -1768,8 +1699,9 @@ pub fn multi_controlled_unitary(
 ///
 /// # Errors
 ///
-/// - [`QubitIndexError`], if `qubit` is outside [0,
-///   [`qureg.num_qubits_represented()`]).
+/// - [`InvalidQuESTInputError`],
+///   - if either `control_qubit` or `target_qubit` is outside [0,
+///     [`qureg.num_qubits_represented()`])
 ///
 /// # Examples
 ///
@@ -1787,16 +1719,13 @@ pub fn multi_controlled_unitary(
 ///
 /// See [QuEST API] for more information.
 ///
-/// [`QubitIndexError`]: crate::QuestError::QubitIndexError
+/// [`InvalidQuESTInputError`]: crate::QuestError::InvalidQuESTInputError
 /// [`qureg.num_qubits_represented()`]: crate::Qureg::num_qubits_represented()
 /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
 pub fn pauli_x(
     qureg: &mut Qureg<'_>,
     target_qubit: i32,
 ) -> Result<(), QuestError> {
-    if target_qubit >= qureg.num_qubits_represented() || target_qubit < 0 {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::pauliX(qureg.reg, target_qubit);
     })
@@ -1811,8 +1740,9 @@ pub fn pauli_x(
 ///
 /// # Errors
 ///
-/// - [`QubitIndexError`], if `qubit` is outside [0,
-///   [`qureg.num_qubits_represented()`]).
+/// - [`InvalidQuESTInputError`],
+///   - if either `control_qubit` or `target_qubit` is outside [0,
+///     [`qureg.num_qubits_represented()`])
 ///
 /// # Examples
 ///
@@ -1830,16 +1760,13 @@ pub fn pauli_x(
 ///
 /// See [QuEST API] for more information.
 ///
-/// [`QubitIndexError`]: crate::QuestError::QubitIndexError
+/// [`InvalidQuESTInputError`]: crate::QuestError::InvalidQuESTInputError
 /// [`qureg.num_qubits_represented()`]: crate::Qureg::num_qubits_represented()
 /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
 pub fn pauli_y(
     qureg: &mut Qureg<'_>,
     target_qubit: i32,
 ) -> Result<(), QuestError> {
-    if target_qubit >= qureg.num_qubits_represented() || target_qubit < 0 {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::pauliY(qureg.reg, target_qubit);
     })
@@ -1854,8 +1781,9 @@ pub fn pauli_y(
 ///
 /// # Errors
 ///
-/// - [`QubitIndexError`], if `qubit` is outside [0,
-///   [`qureg.num_qubits_represented()`]).
+/// - [`InvalidQuESTInputError`],
+///   - if either `control_qubit` or `target_qubit` is outside [0,
+///     [`qureg.num_qubits_represented()`])
 ///
 /// # Examples
 ///
@@ -1873,16 +1801,13 @@ pub fn pauli_y(
 ///
 /// See [QuEST API] for more information.
 ///
-/// [`QubitIndexError`]: crate::QuestError::QubitIndexError
+/// [`InvalidQuESTInputError`]: crate::QuestError::InvalidQuESTInputError
 /// [`qureg.num_qubits_represented()`]: crate::Qureg::num_qubits_represented()
 /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
 pub fn pauli_z(
     qureg: &mut Qureg<'_>,
     target_qubit: i32,
 ) -> Result<(), QuestError> {
-    if target_qubit >= qureg.num_qubits_represented() || target_qubit < 0 {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::pauliZ(qureg.reg, target_qubit);
     })
@@ -1905,8 +1830,9 @@ pub fn pauli_z(
 ///
 /// # Errors
 ///
-/// Returns [`QubitIndexError`][error-qubit-index] if `target_qubit` is
-/// outside [0, [`qureg.num_qubits_represented()`]).
+/// - [`InvalidQuESTInputError`],
+///   - if either `control_qubit` or `target_qubit` is outside [0,
+///     [`qureg.num_qubits_represented()`])
 ///
 /// # Examples
 ///
@@ -1924,16 +1850,13 @@ pub fn pauli_z(
 ///
 /// See [QuEST API] for more information.
 ///
-/// [error-qubit-index]: crate::QuestError::QubitIndexError
+/// [`InvalidQuESTInputError`]: crate::QuestError::InvalidQuESTInputError
 /// [`qureg.num_qubits_represented()`]: crate::Qureg::num_qubits_represented()
 /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
 pub fn hadamard(
     qureg: &mut Qureg<'_>,
     target_qubit: i32,
 ) -> Result<(), QuestError> {
-    if target_qubit < 0 || target_qubit >= qureg.num_qubits_represented() {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::hadamard(qureg.reg, target_qubit);
     })
@@ -1962,10 +1885,9 @@ pub fn hadamard(
 ///
 /// # Errors
 ///
-/// - [`QubitIndexError`],
+/// - [`InvalidQuESTInputError`],
 ///   - if either `control_qubit` or `target_qubit` is outside [0,
 ///     [`qureg.num_qubits_represented()`])
-/// - [`InvalidQuESTInputError`],
 ///   - if `control_qubit` and `target_qubit` are equal
 ///
 /// # Examples
@@ -1987,18 +1909,12 @@ pub fn hadamard(
 ///
 /// [`qureg.num_qubits_represented()`]: crate::Qureg::num_qubits_represented()
 /// [`InvalidQuESTInputError`]: crate::QuestError::InvalidQuESTInputError
-/// [`QubitIndexError`]: crate::QuestError::QubitIndexError
 /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
 pub fn controlled_not(
     qureg: &mut Qureg<'_>,
     control_qubit: i32,
     target_qubit: i32,
 ) -> Result<(), QuestError> {
-    if target_qubit >= qureg.num_qubits_represented()
-        || control_qubit >= qureg.num_qubits_represented()
-    {
-        return Err(QuestError::QubitIndexError);
-    }
     catch_quest_exception(|| unsafe {
         ffi::controlledNot(qureg.reg, control_qubit, target_qubit);
     })

--- a/src/matrices.rs
+++ b/src/matrices.rs
@@ -313,9 +313,7 @@ impl Vector {
 ///
 /// Returns [`Error::ArrayLengthError`](crate::QuestError::ArrayLengthError), if
 /// either `real` or `imag` is not a square array of dimension equal to the
-/// number of qubits in `m`.  Otherwise, returns
-/// [`QuestError::InvalidQuESTInputError`](crate::QuestError::InvalidQuESTInputError) on
-/// failure. This is an exception thrown by `QuEST`.
+/// number of qubits in `m`.
 ///
 /// [QuEST API]: https://quest-kit.github.io/QuEST/modules.html
 #[allow(clippy::cast_sign_loss)]

--- a/src/qureg.rs
+++ b/src/qureg.rs
@@ -34,9 +34,6 @@ impl<'a> Qureg<'a> {
         num_qubits: i32,
         env: &'a QuestEnv,
     ) -> Result<Self, QuestError> {
-        if num_qubits < 0 {
-            return Err(QuestError::QubitIndexError);
-        }
         Ok(Self {
             env,
             reg: catch_quest_exception(|| unsafe {
@@ -67,9 +64,6 @@ impl<'a> Qureg<'a> {
         num_qubits: i32,
         env: &'a QuestEnv,
     ) -> Result<Self, QuestError> {
-        if num_qubits < 0 {
-            return Err(QuestError::QubitIndexError);
-        }
         Ok(Self {
             env,
             reg: catch_quest_exception(|| unsafe {


### PR DESCRIPTION
Now that catching exceptions works correctly (#58), we can remove spurious checks before calling QuEST API.