### PR TITLE
Remove crossbeam crate as dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ gpu = []
 mpi = []
 
 [dependencies]
-crossbeam = "0.8.2"
 log = "0.4.19"
 num = "0.4.0"
 rand = "0.8.5"


### PR DESCRIPTION
We don't need it anymore, as we don't use channels to pass error messages and use panic mechanism instead.